### PR TITLE
ZShell/OhMyZSH Fixes

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -176,7 +176,7 @@ CONTAINER_ENGINE=docker  # Override → affects conditional above
 - **Author:** Jerren Saunders
 - **Test Suite:** Located in `test/` directory with test cases for various features
 - **Documentation:** README.md with comprehensive feature guide
-- **Bash Completion:** `bash-completion/my` for shell completions
+- **Bash Completion:** `auto-complete/my.bash` for bash completions and `auto-complete/_my.zsh` for zsh completions
 
 ## Agent Guidelines
 
@@ -257,4 +257,5 @@ When working on MyCE tasks:
 - **README.md** — Full feature documentation and examples
 - **CHANGE_HISTORY.md** — Version history and changelog
 - **test/** — Test suite with real-world examples
-- **bash-completion/my** — Shell completion definitions
+- **auto-complete/my.bash** — Bash completion definitions
+- **auto-complete/_my.zsh** — ZSH completion definitions

--- a/.myCommands
+++ b/.myCommands
@@ -21,3 +21,14 @@ install.dev=dzdo cp "${REPO_ROOT}/my" "/usr/local/bin/my"; dzdo chown root: "/us
 test=cd ${REPO_ROOT}/test && python3 test.py
 
 smoke=echo -e "Hello \e[0;31m${1:-World}\e[0m"
+
+# Creates a ZSH terminal with MyCE script loaded
+# description: OhMyZSH + MyCE - 'latest' image used by default. Add a tag as an argument to specify a different version (e.g. 'my zsh 5.8')
+zsh=${CONTAINER_ENGINE} run -it --rm \
+    -e ZSH_DISABLE_COMPFIX=true \
+    --volume ${PWD}:/mnt/host \
+    --volume ./my:/usr/local/bin/my \
+    --volume ~/.myCommands:/root/.myCommands \
+    --volume __DIRECTORY__/auto-complete/_my.zsh:/root/.oh-my-zsh/custom/functions/_my \
+    --workdir /mnt/host \
+    docker.io/ohmyzsh/zsh:${1:-latest} zsh

--- a/CHANGE_HISTORY.md
+++ b/CHANGE_HISTORY.md
@@ -1,6 +1,20 @@
 <!-- spell-checker:ignore MYCE -->
 # Change History
 
+## 26.4.29
+
+* **ZSH Completion Support** - Added zsh autocompletion via new `auto-complete/_my.zsh` file
+  * Installs to `/usr/share/zsh/site-functions/_my` when running `my update` from zsh
+  * Detects shell type at runtime and installs appropriate completion file
+* **Completion Directory Renamed** - Renamed `bash-completion/` to `auto-complete/` for clarity
+  * `my.bash` → bash completion file
+  * `_my.zsh` → zsh completion file
+* **Update Script Improvements** - Refactored `update_script` function to detect shell type
+  * Checks `$ZSH_VERSION` and `$BASH_VERSION` to determine shell
+  * Single code path for installation with shell-specific paths defined inline
+* **Documentation Updates** - Updated README.md and AGENTS.md to reflect new completion file locations
+* **New Command** - Added `zsh` command to launch zsh container with MyCE and completion pre-configured
+
 ## 26.4.24
 
 * **Improved Error Handling** - Enhanced "command not found" error reporting by filtering stderr to show only relevant errors while suppressing script-sourced shell errors

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ USAGE:
         update [diff]               Update the script with the latest version.
                                     If 'diff' is given, then show the changes
 
-        ?                           If the command ends with a '?' character, then dry-run mode will be enabled.
+        \?                          If the command ends with a '\?' character, then dry-run mode will be enabled.
                                     This is a special syntax for dry-run mode that can be quickly used to check the command.
                                     Then use the UP arrow to recall the previous command and easily remove the dry-run syntax for execution.
 
@@ -549,14 +549,18 @@ To always disable sourcing the shell rc file, see [MYCE_RUNCOM](#myce_runcom).
 my -c build
 ```
 
-### `?` and `@` Shorthand Suffixes
+### Shorthand Suffixes
 
-#### `?` — Dry-Run Preview
+#### `?` | `\?` — Dry-Run Preview
 
 A shorthand to preview the command that will be expanded, but not actually run the command, is available by adding a trailing `?` on the command.
 When a command that ends with `?` is detected, MyCE will interpret this as a request to print the final command to be executed (and will remove the '?' char).
 The output will include the source file location (SRC), any description (DESC) if defined, and the final command (CMD).
 This shorthand syntax makes it easy to question the command that will be executed, then if it is the command you want, you can:
+
+> [!IMPORTANT]
+> ZSH (including OhMyZSH) has native glob expansion that treats `?` as a single-character wildcard.
+> To use the dry-run suffix in ZSH, you must use an escaped `\?` suffix when using this shell: `my alias \?`
 
 1. Press UP-ARROW to recall the previous command from history
 1. Press BACKSPACE to remove the '?' char

--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ my -c build
 ### `?` and `@` Shorthand Suffixes
 
 #### `?` — Dry-Run Preview
+
 A shorthand to preview the command that will be expanded, but not actually run the command, is available by adding a trailing `?` on the command.
 When a command that ends with `?` is detected, MyCE will interpret this as a request to print the final command to be executed (and will remove the '?' char).
 The output will include the source file location (SRC), any description (DESC) if defined, and the final command (CMD).
@@ -572,6 +573,7 @@ root@my-container:/var/www/html#
 ```
 
 #### `@` — Definition Preview
+
 You can quickly preview where a command is defined by adding a trailing `@` to the command. This acts as a shortcut for the `definition` action, showing the file(s) and line(s) where the command is defined, along with any description.
 
 ```shell
@@ -834,13 +836,13 @@ To take advantage of this feature with MyCE, if you already have the folder `/et
 You may need to run `exec bash` after the update for your shell to load the new feature
 If you're using a different shell or location for your completion scripts, the manual installation instructions are:
 
-1. Copy the bash-completion/my file from this repo to `/etc/bash_completion.d/my`
+1. Copy the `auto-complete/my.bash` file from this repo to `/etc/bash_completion.d/my.bash_completion`
 2. Enable the execute flag (`chmod a+rx`)
 
 This can be done with the following commands (these will likely need to be run as `sudo`)
 
 ```bash
-curl -o /etc/bash_completion.d/my https://raw.githubusercontent.com/jerrens/MyCE/refs/heads/main/bash-completion/my
+curl -o /etc/bash_completion.d/my.bash_completion https://raw.githubusercontent.com/jerrens/MyCE/refs/heads/main/auto-complete/my.bash
 chmod a+rx /etc/bash_completion.d/my
 ```
 

--- a/auto-complete/_my.zsh
+++ b/auto-complete/_my.zsh
@@ -1,0 +1,77 @@
+#compdef my
+
+# Toggle logging - set DEBUG=1 to enable
+DEBUG=${DEBUG:-0}
+
+# Prints log messages to a file if DEBUG is enabled
+function log() {
+    local log_file="/tmp/zsh-my-debug.log"
+    [[ "$DEBUG" == "1" ]] && echo "$@" >> "$log_file"
+}
+
+_my() {
+    log "---- NEW INVOCATION ----"
+    log "words: $words"
+
+    # Remove banner + trim whitespace in one go
+    cmds=("${(@f)$(my list | tail -n +2)}")
+    cmds=("${cmds[@]//(#s)[[:space:]]##/}")
+
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+
+    _arguments -C \
+        '1:firstarg:->first' \
+        '2:subcmd:->second' \
+        '*::args:->args'
+
+    log "state: $state"
+
+    case $state in
+        first)
+            local -a actions
+            actions=(definition list help version update set)
+            log "Offering: ${actions[@]} ${cmds[@]}"
+            compadd -- "${actions[@]}" "${cmds[@]}"
+            return
+            ;;
+        second)
+            local firstarg="$words[2]"
+            case "$firstarg" in
+                update)
+                    log "update opts"
+                    compadd -- diff main head latest release
+                    ;;
+                definition)
+                    local -a all_cmds
+                    all_cmds=("${(@f)$(my list -a | tail -n +2)}")
+                    all_cmds=("${all_cmds[@]//(#s)[[:space:]]##/}")
+                    log "definition completions: ${all_cmds[@]}"
+                    compadd -- "${all_cmds[@]}"
+                    ;;
+                list)
+                    log "list opts"
+                    compadd -- -l -a -d
+                    ;;
+            esac
+            return
+            ;;
+        args)
+            local firstarg="$words[2]"
+            log "firstarg: $firstarg"
+
+            if [[ "$firstarg" == "-d" ]]; then
+                firstarg="$words[3]"
+                log "shifted firstarg: $firstarg"
+            fi
+
+            case "$firstarg" in
+                *)
+                    log "default cmds: ${cmds[@]}"
+                    compadd -- "${cmds[@]}"
+                    return
+                    ;;
+            esac
+            ;;
+    esac
+}

--- a/auto-complete/my.bash
+++ b/auto-complete/my.bash
@@ -3,7 +3,7 @@
 
 # Place this file at: /etc/bash_completion.d/my
 # NOTE: Run the following commands with sudo level:
-# curl -o /etc/bash_completion.d/my https://raw.githubusercontent.com/jerrens/MyCE/refs/heads/main/bash-completion/my
+# curl -o /etc/bash_completion.d/my.bash_completion https://raw.githubusercontent.com/jerrens/MyCE/refs/heads/main/auto-complete/my.bash
 # chmod +x /etc/bash_completion.d/my
 # exec bash
 # 
@@ -48,7 +48,7 @@ _my_autocomplete() {
                 return 0;;
 
             list)
-                COMPREPLY=( $(compgen -W "-l -a" -- "${cur}") )
+                COMPREPLY=( $(compgen -W "-l -a -d" -- "${cur}") )
                 return 0;;
 
             #set)

--- a/my
+++ b/my
@@ -17,13 +17,21 @@ __origArgs=$* # Capture all of the original arguments
 
 # Detect the shell if possible
 if [[ $(type -t ps) == "file" ]]; then
-    __Shell="$( (ps -p $$ -f -o "command=" || echo "$SHELL") | basename "$(cut -d' ' -f1)" 2>/dev/null )"
+    __Shell="$( (ps -p "$PPID" -o comm= || echo "$SHELL") | basename "$(cut -d' ' -f1)" 2>/dev/null )"
 fi
 __Shell="${__Shell:-false}"
 
 
 function print_usage() {
     includeAppInfo=${1}
+
+    local shorthand_dryrun=""
+    if [[ $__Shell == "zsh" ]]; then
+        shorthand_dryrun="\?"
+    else # Assume BASH
+        shorthand_dryrun="? "
+    fi
+    
     cat <<EOT
 
 This script will search the current directory tree for a file named '${MY_CUSTOM_FILE}', containing
@@ -51,7 +59,7 @@ USAGE:
         update [diff]               Update the script with the latest version.
                                     If 'diff' is given, then show the changes
 
-        ?                           If the command ends with a '?' character, then dry-run mode will be enabled.
+        ${shorthand_dryrun}                          If the command ends with a '${shorthand_dryrun%%[[:space:]]}' character, then dry-run mode will be enabled.
                                     This is a special syntax for dry-run mode that can be quickly used to check the command.
                                     Then use the UP arrow to recall the previous command and easily remove the dry-run syntax for execution.
 
@@ -1640,13 +1648,11 @@ function update_script() {
 
     # Determine installation auto-completion based on shell type
     local shell_type src_file dest_file completion_dir
-    if [[ -n "$ZSH_VERSION" ]]; then
-        shell_type="zsh"
+    if [[ $__Shell == "zsh" ]]; then
         src_file="/tmp/${archive_root}/auto-complete/_my.zsh"
         dest_file="/usr/share/zsh/site-functions/_my"
         completion_dir="/usr/share/zsh/site-functions"
-    elif [[ -n "$BASH_VERSION" ]]; then
-        shell_type="bash"
+    else # Assume BASH
         src_file="/tmp/${archive_root}/auto-complete/my.bash"
         dest_file="/etc/bash_completion.d/my.bash_completion"
         completion_dir="/etc/bash_completion.d"
@@ -1654,7 +1660,7 @@ function update_script() {
 
     # Now that we know the shell type, move the appropriate completion file and set permissions
     if [[ -n "$src_file" && -n "$dest_file" && -d "${completion_dir}" ]]; then
-        log 1 "Updating ${shell_type} completion file at ${completion_dir}..."
+        log 1 "Updating ${__Shell} completion file at ${completion_dir}..."
         runCMD mv --force "$src_file" "$dest_file"
         runCMD chmod 644 "$dest_file"
     fi

--- a/my
+++ b/my
@@ -8,7 +8,7 @@ __MYCE_ORIGINAL_IFS="$IFS"
 trap 'IFS="$__MYCE_ORIGINAL_IFS"' EXIT INT TERM
 
 __Author="Jerren Saunders"
-__Version=26.4.24
+__Version=26.4.29
 __ExePath="$0" # Executable path as called
 __ScriptName=$(basename "$0") # File name with extension
 __AppDir=$(dirname "$0") # Path where script is stored
@@ -1539,7 +1539,7 @@ function download_latest_release() {
 
     # Extract the downloaded archive
     # archive_root="MyCE-${tag#v}"
-    tar -xzf "${temp_file}" --directory /tmp --wildcards "${archive_root}/my" --wildcards "${archive_root}/bash-completion/*"
+    tar -xzf "${temp_file}" --directory /tmp --wildcards "${archive_root}/my" --wildcards "${archive_root}/auto-complete/*"
 }
 
 
@@ -1638,12 +1638,25 @@ function update_script() {
     log 1 "\nModifying permissions..."
     runCMD chmod a+x "${install_path}"
 
-    # Install auto-completion (if path exists)
-    local completion_dir="/etc/bash_completion.d"
-    if [[ -d "${completion_dir}" ]]; then
-        log 1 "Updating auto-completion file at ${completion_dir}..."
-        runCMD mv --force "/tmp/${archive_root}/bash-completion/my" "${completion_dir}/my.bash_completion"
-        runCMD chmod 644 "${completion_dir}/my.bash_completion"
+    # Determine installation auto-completion based on shell type
+    local shell_type src_file dest_file completion_dir
+    if [[ -n "$ZSH_VERSION" ]]; then
+        shell_type="zsh"
+        src_file="/tmp/${archive_root}/auto-complete/_my.zsh"
+        dest_file="/usr/share/zsh/site-functions/_my"
+        completion_dir="/usr/share/zsh/site-functions"
+    elif [[ -n "$BASH_VERSION" ]]; then
+        shell_type="bash"
+        src_file="/tmp/${archive_root}/auto-complete/my.bash"
+        dest_file="/etc/bash_completion.d/my.bash_completion"
+        completion_dir="/etc/bash_completion.d"
+    fi
+
+    # Now that we know the shell type, move the appropriate completion file and set permissions
+    if [[ -n "$src_file" && -n "$dest_file" && -d "${completion_dir}" ]]; then
+        log 1 "Updating ${shell_type} completion file at ${completion_dir}..."
+        runCMD mv --force "$src_file" "$dest_file"
+        runCMD chmod 644 "$dest_file"
     fi
 
     log 0 "Update finished!"


### PR DESCRIPTION
* **ZSH Completion Support** - Added zsh autocompletion via new `auto-complete/_my.zsh` file
  * Installs to `/usr/share/zsh/site-functions/_my` when running `my update` from zsh
  * Detects shell type at runtime and installs appropriate completion file
* **Completion Directory Renamed** - Renamed `bash-completion/` to `auto-complete/` for clarity
  * `my.bash` → bash completion file
  * `_my.zsh` → zsh completion file
* **Update Script Improvements** - Refactored `update_script` function to detect shell type
  * Checks `$ZSH_VERSION` and `$BASH_VERSION` to determine shell
  * Single code path for installation with shell-specific paths defined inline
* **Documentation Updates** - Updated README.md and AGENTS.md to reflect new completion file locations
* **New Command** - Added `zsh` command to launch zsh container with MyCE and completion pre-configured