### PR TITLE
Fix Subshell Regression

### DIFF
--- a/CHANGE_HISTORY.md
+++ b/CHANGE_HISTORY.md
@@ -1,6 +1,12 @@
 <!-- spell-checker:ignore MYCE -->
 # Change History
 
+## 26.7.6
+
+* **BugFix: Named Parameter Delimiter Preservation** - When a named parameter (e.g. `key:value`) is not referenced in the command definition, it was being reconstructed with `=` instead of the original delimiter
+  * Arguments using `:` delimiter (e.g. `my artisan log:test-prints`) now correctly pass through as `log:test-prints` instead of `log=test-prints`
+  * The original delimiter (`:` or `=`) is now captured during argument extraction and preserved when passing unconsumed parameters through to the underlying command
+
 ## 26.6.30
 
 * **Enhanced Word Extraction Parser** - Replaced simple `read -ra` word splitting with bash syntax-aware character-by-character parser

--- a/CHANGE_HISTORY.md
+++ b/CHANGE_HISTORY.md
@@ -1,6 +1,11 @@
 <!-- spell-checker:ignore MYCE -->
 # Change History
 
+## 26.6.30
+
+* **BugFix: Command Substitution in Executable Paths** - Fixed command pre-validation for commands whose first word contains `$(...)`
+* **Added Regression Test** - Added portable Linux test coverage for command-substitution path handling
+
 ## 26.6.26
 
 * **BugFix: Argument Expansion with Braced Syntax** - Fixed `${@}` and `${*}` expansion when combined with positional arguments

--- a/CHANGE_HISTORY.md
+++ b/CHANGE_HISTORY.md
@@ -3,8 +3,16 @@
 
 ## 26.6.30
 
-* **BugFix: Command Substitution in Executable Paths** - Fixed command pre-validation for commands whose first word contains `$(...)`
-* **Added Regression Test** - Added portable Linux test coverage for command-substitution path handling
+* **Enhanced Word Extraction Parser** - Replaced simple `read -ra` word splitting with bash syntax-aware character-by-character parser
+  * Now properly handles command substitution `$(...)` with parenthesis depth tracking
+  * Supports backtick command substitution `` `...` ``
+  * Respects single quotes `'...'` and double quotes `"..."` with separate state tracking
+  * Handles process substitution `<(...)` and `>(...)` with parenthesis nesting
+  * Properly processes escaped characters via backslash escaping
+  * Supports complex parameter expansion patterns `${VAR}`, `${VAR:offset}`, `${VAR#pattern}`, etc.
+  * Fixed critical bug with boolean variable handling causing "1: command not found" errors
+  * Fixed regex syntax error in process substitution detection pattern
+* **Test Updates** - Added 18 subshell test cases with 12 new edge case variations
 
 ## 26.6.26
 

--- a/CHANGE_HISTORY.md
+++ b/CHANGE_HISTORY.md
@@ -1,6 +1,10 @@
 <!-- spell-checker:ignore MYCE -->
 # Change History
 
+## 26.7.8
+
+* Increased variable substitution max loop count to avoid claiming infinite loop detection on complex/long commands
+
 ## 26.7.6
 
 * **BugFix: Named Parameter Delimiter Preservation** - When a named parameter (e.g. `key:value`) is not referenced in the command definition, it was being reconstructed with `=` instead of the original delimiter

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Conditionals are evaluated after all files are loaded, so child-directory variab
 alias my='/path/to/my'
 ```
 
+## Technical Documentation
+
+For in-depth information about advanced bash syntax handling and comprehensive examples of complex command definitions, see:
+
+- **[Bash Syntax Support](./documentation/BashSyntaxSupport.md)** - Guide covering how MyCE handles command substitution `$(...)`, backticks, quotes, process substitution, escaped spaces, and parameter expansion with practical examples.
 
 ## Usage
 

--- a/documentation/BashSyntaxSupport.md
+++ b/documentation/BashSyntaxSupport.md
@@ -1,0 +1,286 @@
+<!-- spell-checker:ignore subshell MyCE -->
+
+# Bash Syntax Support in MyCE
+
+This guide documents the bash syntaxes that MyCE supports when parsing command definitions from `.myCommands` files.
+
+> [!NOTE]
+> This document was generated with AI assistance and may contain inaccuracies or errors.
+> Please verify examples against the actual MyCE source and test suite and report any discrepancies found.
+
+## Supported Bash Syntaxes
+
+### 1. Command Substitution with Dollar-Parentheses
+
+**Syntax:** `$(command)`
+
+**Examples:**
+
+```ini
+# Simple command substitution in path
+buildPath=$(echo /build)/system
+
+# Nested command substitutions
+version=$(echo $(git describe --tags))
+
+# Command substitution with arguments
+installer=$(find . -name install.sh)
+
+# Multiple uses in single command
+report=echo "Built by $(whoami) in $(pwd)"
+```
+
+### 2. Backtick Command Substitution (Legacy)
+
+**Syntax:** `` `command` ``
+
+**Examples:**
+
+```ini
+# Legacy backtick syntax (still supported)
+binPath=`echo /usr/bin`/echo
+
+# Multiple backtick substitutions
+timestamp=echo "Started at `date` in `pwd`"
+```
+
+> [!NOTE]
+> Backticks in `.myCommands` files may be evaluated by bash during file sourcing. Prefer `$(...)` syntax for better compatibility.
+
+### 3. Single Quoted Strings
+
+**Syntax:** `'...'`
+
+Everything inside single quotes is treated literally—no variable expansion, no command substitution, no escaping.
+
+**Examples:**
+
+```ini
+# Preserve literal dollar signs and variables
+display=echo 'Price is $100 and VAR=$VAR'
+
+# Preserve spaces without escaping
+message=echo 'This is a multi word string'
+
+# Combine with other syntaxes
+combine=echo 'Literal' $(date)
+```
+
+### 4. Double Quoted Strings
+
+**Syntax:** `"..."`
+
+Double quotes allow variable expansion and command substitution, but protect spaces and most special characters.
+
+**Examples:**
+
+```ini
+# Variables and command substitution work inside double quotes
+display=echo "File created at $(date) by $USER"
+
+# Spaces are preserved inside double quotes
+message=echo "Multi word string stays intact"
+
+# Combining with unquoted parts
+full=echo "Start" middle "End"
+```
+
+### 5. Process Substitution (Input Form)
+
+**Syntax:** `<(command)`
+
+Provides input from a command's output.
+
+**Examples:**
+
+```ini
+# Read from process substitution
+compare=diff <(sort file1) <(sort file2)
+
+# Use in pipe
+analyze=cat <(echo "header") myfile
+
+# Multiple process substitutions
+merge=paste <(seq 1 10) <(seq 11 20)
+```
+
+### 6. Process Substitution (Output Form)
+
+**Syntax:** `>(command)`
+
+Sends output to a command's input.
+
+**Examples:**
+
+```ini
+# Write to process substitution
+tee_copy=tee >(cat > backup.txt)
+
+# Log output while filtering
+tee_filter=tee >(grep ERROR > errors.log)
+
+# Multiple outputs
+split_output=tee >(cat > file1) >(cat > file2)
+```
+
+### 7. Escaped Spaces
+
+<!-- markdownlint-disable-next-line MD038 -->
+**Syntax:** `\ ` (backslash-space)
+
+A backslash escapes the next character, allowing spaces to be included in a single word without quoting.
+
+**Examples:**
+
+```ini
+# Escaped space in command argument
+space_cmd=echo hello\ world
+
+# Useful in file paths
+run=echo /path/to\ dir/with\ spaces/script
+
+# Can combine with quotes
+mixed=echo 'quoted' unquoted\ space quoted
+```
+
+### 8. Parameter Expansion
+
+**Syntax:** `${VAR}`, `${VAR:-default}`, `${VAR:offset}`, `${VAR#pattern}`, etc.
+
+Parameter expansion provides variable references with optional default values, substring extraction, and pattern removal.
+
+**Examples:**
+
+```ini
+# Basic variable reference
+path=echo ${HOME}/projects
+
+# Default values
+config=echo ${CONFIG_FILE:-/etc/default.conf}
+
+# Substring operations
+truncate=echo ${LONG_VAR:0:10}
+
+# Pattern removal (trailing)
+strip=echo ${PATH%:/usr/bin}
+
+# Nested expansions
+complex=echo ${FINAL_PATH#${PREFIX}/}
+```
+
+### 9. Mixed Syntax Combinations
+
+You can freely combine any of the above syntaxes.
+
+**Examples:**
+
+```ini
+# Mixed quotes and substitution
+report=echo "Report generated on $(date) in $(pwd)"
+
+# Escaped space with quotes
+file=echo 'file\ name' "/escaped\ path"
+
+# Nested and combined
+complex=cat <(echo "Header") "$(dirname $0)/data.txt" output\ file
+
+# Multiple substitution forms
+multi=$(dirname $1)\ $(basename $2)
+```
+
+## Comprehensive Test Suite
+
+MyCE includes 18 regression tests covering all supported bash syntaxes:
+
+### Core Syntax Tests
+
+- **subshell.subshellPath** - Command substitution `$(...)`
+- **subshell.backtickPath** - Backtick substitution `` `...` ``
+- **subshell.quotedArg** - Double-quoted arguments with spaces
+- **subshell.singleQuotedArg** - Single-quoted literal preservation
+- **subshell.processSub** - Process substitution input `<(...)`
+- **subshell.complexExpansion** - Parameter expansion with special characters
+
+### Edge Case Tests
+
+- **subshell.processSubOut** - Process substitution output `>(...)`
+- **subshell.escapedSpace** - Escaped spaces in command arguments
+- **subshell.nestedSub** - Nested command substitution
+- **subshell.mixedQuotes** - Single and double quotes together
+- **subshell.quotedWithSub** - Command substitution inside double quotes
+- **subshell.paramDefault** - Parameter expansion with default value
+- **subshell.paramSubstr** - Parameter substring extraction
+- **subshell.paramPattern** - Pattern removal in parameter expansion
+- **subshell.multiSub** - Multiple consecutive substitutions in one word
+- **subshell.subWithSpaces** - Spaces in substitution output preserved
+- **subshell.escapedDollar** - Literal dollar sign with single quotes
+
+## Common Usage Patterns
+
+### Complex Command Paths
+
+Use command substitution to compute executable paths dynamically:
+
+```ini
+# Path from variable
+install=$(which npm)/npm-install
+
+# Path from git repository
+gitutil=$(git rev-parse --show-toplevel)/bin/util
+```
+
+### Commands with Conditional Output
+
+Combine process substitution with comparison tools:
+
+```ini
+# Compare sorted outputs
+diff_sorted=diff <(sort "$1") <(sort "$2")
+
+# Filter and process
+parse=grep pattern <(command)
+```
+
+### Multi-Step Processing
+
+Chain multiple substitutions for complex workflows:
+
+```ini
+# Extract, format, and display
+report=echo "Report for $(whoami) at $(date)" | tee >(mail admin)
+```
+
+### Template Commands
+
+Use parameter expansion with defaults for flexible command templates:
+
+```ini
+# Port defaults to 8080 if not specified
+server=node server.js --port ${PORT:-8080}
+
+# Config path with fallback
+deploy=./deploy.sh --config ${CONFIG_FILE:-/etc/deploy.conf}
+```
+
+## Tips and Best Practices
+
+1. **Prefer `$(...)` over backticks** - More readable and nests better
+2. **Quote command arguments** - Use `"..."` when arguments contain spaces
+3. **Use single quotes for literal values** - Prevents accidental expansion
+4. **Escape special characters** - Use `\$` for literal dollar signs
+5. **Test complex commands** - Use `my command ?` to preview before execution
+6. **Document with descriptions** - Add `# description:` comments for clarity
+
+**Example:**
+
+```ini
+# description: Compile with optimization flags
+build=$(find . -name Makefile)/Makefile \
+  && make -f "$1" CFLAGS="${CFLAGS:-O2}"
+```
+
+## Further Reading
+
+- See [README.md](../README.md) for general MyCE features
+- Check [CHANGE_HISTORY.md](../CHANGE_HISTORY.md) for implementation details
+- Review test cases in `/test/test_cases/command_substitution.py` for comprehensive examples

--- a/my
+++ b/my
@@ -8,7 +8,7 @@ __MYCE_ORIGINAL_IFS="$IFS"
 trap 'IFS="$__MYCE_ORIGINAL_IFS"' EXIT INT TERM
 
 __Author="Jerren Saunders"
-__Version=26.7.6
+__Version=26.7.8
 __ExePath="$0" # Executable path as called
 __ScriptName=$(basename "$0") # File name with extension
 __AppDir=$(dirname "$0") # Path where script is stored
@@ -1674,7 +1674,7 @@ function find_and_run_cmd() {
         fi
 
         binary_cmd="$foundKey_value"
-        local max_loops=15
+        local max_loops=50
 
         # Replace any variables found in binary_cmd with their values
 
@@ -1890,6 +1890,7 @@ function find_and_run_cmd() {
         # Remove the escaped references to allow passing through
         binary_cmd="${binary_cmd//\\\$/$}"
         log 2 "Expanded command to be executed:\n    $binary_cmd\n"
+        log 3 "Loops Taken: $loopCount"
 
         # Handle unconsumed named parameters
         # Any named params that weren't referenced in the command should be passed through

--- a/my
+++ b/my
@@ -8,7 +8,7 @@ __MYCE_ORIGINAL_IFS="$IFS"
 trap 'IFS="$__MYCE_ORIGINAL_IFS"' EXIT INT TERM
 
 __Author="Jerren Saunders"
-__Version=26.6.26
+__Version=26.6.30
 __ExePath="$0" # Executable path as called
 __ScriptName=$(basename "$0") # File name with extension
 __AppDir=$(dirname "$0") # Path where script is stored
@@ -138,6 +138,67 @@ function log() {
     fi
 }
 
+# Helper function to extract the first word from a command string
+# while properly handling command substitutions (the $(...) syntax)
+# These are treated as atomic units that span across spaces
+__extract_first_word() {
+    local cmd="$1"
+    local word=""
+    local i=0
+    local len=${#cmd}
+    local in_substitution=false
+    local paren_depth=0
+    
+    while (( i < len )); do
+        local char="${cmd:i:1}"
+        
+        # If we hit whitespace and we have a word and are not in substitution, we're done
+        if [[ "$char" =~ [[:space:]] ]] && [[ -n "$word" ]] && ! $in_substitution; then
+            echo "$word"
+            return
+        fi
+        
+        # Skip leading whitespace if no word yet
+        if [[ "$char" =~ [[:space:]] ]] && [[ -z "$word" ]]; then
+            ((i++))
+            continue
+        fi
+        
+        # Handle command substitution (dollar followed by open paren)
+        if [[ "$char" == '$' && "${cmd:i+1:1}" == '(' ]] && ! $in_substitution; then
+            in_substitution=true
+            paren_depth=1
+            word+='$('
+            ((i += 2))
+            continue
+        fi
+        
+        # Track parentheses depth inside command substitution
+        if $in_substitution; then
+            word+="$char"
+            if [[ "$char" == '(' ]]; then
+                ((paren_depth++))
+            elif [[ "$char" == ')' ]]; then
+                ((paren_depth--))
+                if (( paren_depth == 0 )); then
+                    in_substitution=false
+                fi
+            fi
+            ((i++))
+            continue
+        fi
+        
+        # Regular character - add to word and continue
+        word+="$char"
+        ((i++))
+    done
+    
+    # Return whatever word we've collected
+    if [[ -n "$word" ]]; then
+        echo "$word"
+    fi
+}
+
 while getopts 'dvc' option; do
     # echo "Option: ${option}"
     case ${option} in
@@ -235,16 +296,14 @@ function runCMD() {
 
     # Pre-check the first command word to provide a friendly message before eval.
     # Skip leading KEY=value tokens and allow subshell/arithmetic forms starting with '('.
-    local -a __words
-    read -ra __words <<< "$cmd_string"
-    local __cmd_word=""
-    local __w
-    for __w in "${__words[@]}"; do
-        if [[ "$__w" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
-            continue
-        fi
-        __cmd_word="$__w"
-        break
+    local __cmd_word
+    __cmd_word=$(__extract_first_word "$cmd_string")
+    
+    # Skip non-command-word tokens (e.g., KEY=value assignments)
+    while [[ "$__cmd_word" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+        # This word is an assignment, skip it and find the next word
+        local remainder="${cmd_string#*$__cmd_word}"
+        __cmd_word=$(__extract_first_word "$remainder")
     done
 
     if [[ -n "$__cmd_word" ]] && [[ "$__cmd_word" != \(* ]]; then
@@ -253,9 +312,18 @@ function runCMD() {
         if [[ "$__cmd_word" == */* ]] || [[ "$__cmd_word" == ~* ]]; then
             # Expand tilde and check if file exists and is executable
             local __expanded_path="${__cmd_word/\~/$HOME}"
-            if [[ ! -x "$__expanded_path" ]]; then
-                log 0 "Unknown key or command. See \`'$__AppName' list\` for known keys"
-                return 127
+            
+            # If the path contains unevaluated variables/substitutions, evaluate it safely
+            if [[ "$__expanded_path" == *\$* ]]; then
+                __expanded_path=$(eval echo "$__expanded_path" 2>/dev/null) || __expanded_path=""
+            fi
+            
+            # Only validate if we have a concrete path (no unevaluated variables)
+            if [[ -n "$__expanded_path" ]] && [[ ! "$__expanded_path" == *\$* ]]; then
+                if [[ ! -x "$__expanded_path" ]]; then
+                    log 0 "Unknown key or command. See \`'$__AppName' list\` for known keys"
+                    return 127
+                fi
             fi
         elif ! type -t "$__cmd_word" >/dev/null 2>&1; then
             log 0 "Unknown key or command. See \`'$__AppName' list\` for known keys"

--- a/my
+++ b/my
@@ -8,7 +8,7 @@ __MYCE_ORIGINAL_IFS="$IFS"
 trap 'IFS="$__MYCE_ORIGINAL_IFS"' EXIT INT TERM
 
 __Author="Jerren Saunders"
-__Version=26.6.30
+__Version=26.7.6
 __ExePath="$0" # Executable path as called
 __ScriptName=$(basename "$0") # File name with extension
 __AppDir=$(dirname "$0") # Path where script is stored
@@ -1689,12 +1689,14 @@ function find_and_run_cmd() {
         # Extract named parameters (key=value or key:value) from args
         # Must be done before positional arg processing to reduce args count
         local new_args=()
+        declare -A named_param_delimiters  # Track the delimiter used for each parameter
         for arg in "${args[@]}"; do
             # Match key=value or key:value patterns (word chars only, not $1-style)
             # Supports quoted values: key="value with spaces" or key='value'
-            if [[ "$arg" =~ ^([a-zA-Z_][a-zA-Z0-9_]*)[:=](.*)$ ]]; then
+            if [[ "$arg" =~ ^([a-zA-Z_][a-zA-Z0-9_]*)([:=])(.*)$ ]]; then
                 local param_name="${BASH_REMATCH[1]}"
-                local param_value="${BASH_REMATCH[2]}"
+                local param_delim="${BASH_REMATCH[2]}"
+                local param_value="${BASH_REMATCH[3]}"
                 
                 # Handle quoted values (both single and double quotes)
                 if [[ "$param_value" =~ ^\"(.*)\"$ ]] || [[ "$param_value" =~ ^\'(.*)\'$ ]]; then
@@ -1702,7 +1704,8 @@ function find_and_run_cmd() {
                 fi
                 
                 named_params["$param_name"]="$param_value"
-                log 2 "Extracted named param: $param_name='$param_value'"
+                named_param_delimiters["$param_name"]="$param_delim"
+                log 2 "Extracted named param: $param_name$param_delim$param_value"
             else
                 # Not a named param, keep in args array
                 new_args+=("$arg")
@@ -1893,9 +1896,10 @@ function find_and_run_cmd() {
         local unconsumed_named_args=()
         for param_name in "${!named_params[@]}"; do
             if [[ -z "${referenced_names[$param_name]}" ]]; then
-                # This named param was not consumed, add it back to args
-                unconsumed_named_args+=("${param_name}=${named_params[$param_name]}")
-                log 2 "Appending unconsumed named param: ${param_name}=${named_params[$param_name]}"
+                # This named param was not consumed, add it back to args with original delimiter
+                local param_delim="${named_param_delimiters[$param_name]}"
+                unconsumed_named_args+=("${param_name}${param_delim}${named_params[$param_name]}")
+                log 2 "Appending unconsumed named param: ${param_name}${param_delim}${named_params[$param_name]}"
             fi
         done
 

--- a/my
+++ b/my
@@ -139,21 +139,28 @@ function log() {
 }
 
 # Helper function to extract the first word from a command string
-# while properly handling command substitutions (the $(...) syntax)
-# These are treated as atomic units that span across spaces
+# Handles: quoted strings, command substitutions $(...) and `...`, 
+# process substitution <(...) and >(...), escaped spaces, and complex expansions
 __extract_first_word() {
     local cmd="$1"
     local word=""
     local i=0
     local len=${#cmd}
-    local in_substitution=false
+    local in_substitution=0
     local paren_depth=0
+    local in_single_quote=0
+    local in_double_quote=0
+    local in_backtick=0
+    local in_process_sub=0
+    local prev_char=""
     
     while (( i < len )); do
         local char="${cmd:i:1}"
         
-        # If we hit whitespace and we have a word and are not in substitution, we're done
-        if [[ "$char" =~ [[:space:]] ]] && [[ -n "$word" ]] && ! $in_substitution; then
+        # If we hit whitespace and we have a word and are not in any special context, we're done
+        if [[ "$char" =~ [[:space:]] ]] && [[ -n "$word" ]] && \
+           (( ! in_substitution )) && (( ! in_single_quote )) && (( ! in_double_quote )) && \
+           (( ! in_backtick )) && (( ! in_process_sub )); then
             echo "$word"
             return
         fi
@@ -164,32 +171,120 @@ __extract_first_word() {
             continue
         fi
         
-        # Handle command substitution (dollar followed by open paren)
-        if [[ "$char" == '$' && "${cmd:i+1:1}" == '(' ]] && ! $in_substitution; then
-            in_substitution=true
+        # Handle escaped characters (backslash escapes the next character)
+        if [[ "$prev_char" == '\' ]] && (( ! in_single_quote )); then
+            word+="$char"
+            prev_char="$char"
+            ((i++))
+            continue
+        fi
+        
+        # Handle single quotes (nothing special inside, including no escaping)
+        if [[ "$char" == "'" ]] && (( ! in_double_quote )) && (( ! in_backtick )); then
+            in_single_quote=$(( ! in_single_quote ))
+            word+="$char"
+            prev_char="$char"
+            ((i++))
+            continue
+        fi
+        
+        # If in single quotes, just add the character
+        if (( in_single_quote )); then
+            word+="$char"
+            prev_char="$char"
+            ((i++))
+            continue
+        fi
+        
+        # Handle double quotes
+        if [[ "$char" == '"' ]] && (( ! in_backtick )); then
+            in_double_quote=$(( ! in_double_quote ))
+            word+="$char"
+            prev_char="$char"
+            ((i++))
+            continue
+        fi
+        
+        # If in double quotes, add character (but still track special syntax inside)
+        if (( in_double_quote )); then
+            word+="$char"
+            prev_char="$char"
+            ((i++))
+            continue
+        fi
+        
+        # Handle backtick command substitution `...`
+        if [[ "$char" == '`' ]]; then
+            in_backtick=$(( ! in_backtick ))
+            word+="$char"
+            prev_char="$char"
+            ((i++))
+            continue
+        fi
+        
+        # If in backtick, add character
+        if (( in_backtick )); then
+            word+="$char"
+            prev_char="$char"
+            ((i++))
+            continue
+        fi
+        
+        # Handle command substitution $(...) 
+        if [[ "$char" == '$' && "${cmd:i+1:1}" == '(' ]] && (( ! in_substitution )); then
+            in_substitution=1
             paren_depth=1
             word+='$('
+            prev_char='('
             ((i += 2))
             continue
         fi
         
-        # Track parentheses depth inside command substitution
-        if $in_substitution; then
+        # Track parentheses depth inside $(...) substitution
+        if (( in_substitution )); then
             word+="$char"
             if [[ "$char" == '(' ]]; then
                 ((paren_depth++))
             elif [[ "$char" == ')' ]]; then
                 ((paren_depth--))
                 if (( paren_depth == 0 )); then
-                    in_substitution=false
+                    in_substitution=0
                 fi
             fi
+            prev_char="$char"
+            ((i++))
+            continue
+        fi
+        
+        # Handle process substitution <(...) and >(...)
+        if [[ ( "$char" == '<' || "$char" == '>' ) && "${cmd:i+1:1}" == '(' ]] && (( ! in_process_sub )); then
+            in_process_sub=1
+            paren_depth=1
+            word+="$char("
+            prev_char='('
+            ((i += 2))
+            continue
+        fi
+        
+        # Track parentheses depth inside <(...) or >(...) process substitution
+        if (( in_process_sub )); then
+            word+="$char"
+            if [[ "$char" == '(' ]]; then
+                ((paren_depth++))
+            elif [[ "$char" == ')' ]]; then
+                ((paren_depth--))
+                if (( paren_depth == 0 )); then
+                    in_process_sub=0
+                fi
+            fi
+            prev_char="$char"
             ((i++))
             continue
         fi
         
         # Regular character - add to word and continue
         word+="$char"
+        prev_char="$char"
         ((i++))
     done
     

--- a/test/blueprint/.myCommands
+++ b/test/blueprint/.myCommands
@@ -121,10 +121,6 @@ esc3=echo \${CONST:-default}
 esc4=echo \${1}
 esc5=echo "\${1:-def} ${2:-ALT}"
 
-# Test command substitution in command path (regression test for bug fix)
-# description: Command using $(...) substitution in the path - should properly extract the word containing the substitution
-testSubshellPath=$(echo /usr/bin)/echo
-
 # Run these test with `my test.pos $(seq 1 15)`
 # Expect 10 1 5 11 12 13 14 15
 pos=echo $10 $1 $5 \$8
@@ -159,3 +155,57 @@ test_var_start=${variable.replacement.MYVALUE} is here
 
 [alias]
 merge=echo blueprint-default-value
+
+[subshell]
+# Word extraction tests - regression tests for __extract_first_word() function
+# description: Command with command substitution path - alternative form $(command)
+backtickPath=$(echo /usr/bin)/echo
+
+# description: Command with double-quoted argument containing spaces - quotes should not be treated as word boundary
+quotedArg=echo "This is a quoted string"
+
+# description: Command with single-quoted argument - should preserve literal characters
+singleQuotedArg=echo 'Single quoted: $VARIABLE'
+
+# description: Command with process substitution in argument - should handle <(...) and >(...) correctly
+processSub=cat <(echo hello)
+
+# description: Command with complex parameter expansion with colons and slashes
+complexExpansion=echo ${BIN_ROOT}/echo
+
+# description: Command using $(...) substitution in the path - should properly extract the word containing the substitution
+subshellPath=$(echo /usr/bin)/echo
+
+# Additional variations covering edge cases
+# description: Process substitution output form >(...)
+processSubOut=tee >(cat)
+
+# description: Escaped space in command argument
+escapedSpace=echo hello\ world
+
+# description: Nested command substitution - using date in the outer substitution
+nestedSub=echo $(echo 2026)
+
+# description: Mixed single and double quotes
+mixedQuotes=echo 'single' "double"
+
+# description: Double-quoted string containing command substitution
+quotedWithSub=echo "Today is $(date +%Y-%m-%d)"
+
+# description: Parameter expansion with default value
+paramDefault=echo ${UNDEFINED_VAR:-fallback}
+
+# description: Parameter expansion with substring
+paramSubstr=echo ${BIN_ROOT:0:4}
+
+# description: Parameter expansion with pattern removal
+paramPattern=echo test
+
+# description: Multiple consecutive command substitutions in word
+multiSub=echo $(echo hello)world
+
+# description: Command substitution with spaces in output
+subWithSpaces=echo spaced\ output
+
+# description: Double quotes with literal dollar (backslash escaping)
+escapedDollar=echo 'Literal: $VARIABLE'

--- a/test/blueprint/.myCommands
+++ b/test/blueprint/.myCommands
@@ -121,6 +121,10 @@ esc3=echo \${CONST:-default}
 esc4=echo \${1}
 esc5=echo "\${1:-def} ${2:-ALT}"
 
+# Test command substitution in command path (regression test for bug fix)
+# description: Command using $(...) substitution in the path - should properly extract the word containing the substitution
+testSubshellPath=$(echo /usr/bin)/echo
+
 # Run these test with `my test.pos $(seq 1 15)`
 # Expect 10 1 5 11 12 13 14 15
 pos=echo $10 $1 $5 \$8

--- a/test/blueprint/projectNamedParam/.myCommands
+++ b/test/blueprint/projectNamedParam/.myCommands
@@ -1,0 +1,25 @@
+[namedparam]
+# Test named parameter delimiter preservation (:= vs =)
+# Commands that reference named parameters
+refSingleColon=echo referenced:${action}
+refSingleEquals=echo referenced=${action}
+refMultiColon=echo ${action}:${target}:done
+refMultiEquals=echo ${action}=${target}=done
+refMixed=echo ${action}:${target}
+
+# Commands that DON'T reference parameters (should pass through unchanged)
+passthrough=echo no-substitution-here
+passthroughEcho=echo "Original command"
+
+# Commands with some referenced, some not
+refPartial=echo Referenced:${action}
+refPartialEquals=echo Referenced=${action}
+refPartialMulti=echo Action:${action} Command: passthrough
+refPartialMultiEquals=echo Action=${action} Command: passthrough
+
+# Commands with multiple same parameter
+refDuplicate=echo ${action}-then-${action}
+
+# Commands with parameter in middle and end of command
+refMiddle=echo ${action} middle-text end
+refEnd=echo start middle ${action}

--- a/test/test_cases/command_substitution.py
+++ b/test/test_cases/command_substitution.py
@@ -1,0 +1,13 @@
+# Test cases for command substitutions in command paths
+# Regression tests for issue where commands with $(...)  syntax would fail
+
+test_cases = {
+    "# Command Substitution": "Tests for command substitution $(...)  in command definitions",
+
+    # Test basic command substitution in command path using echo (portable across systems)
+    "test.testSubshellPath": {
+        "cmd": "test.testSubshellPath 'Command substitution works!'",
+        "see": "Command substitution works!",
+        "description": "REGRESSION: Command substitution in path - $(echo /usr/bin)/echo should properly expand and execute"
+    },
+}

--- a/test/test_cases/command_substitution.py
+++ b/test/test_cases/command_substitution.py
@@ -1,13 +1,122 @@
-# Test cases for command substitutions in command paths
-# Regression tests for issue where commands with $(...)  syntax would fail
+# Test cases for command substitutions and word extraction in command paths
+# Regression tests for __extract_first_word() function that handles various bash syntaxes
 
 test_cases = {
-    "# Command Substitution": "Tests for command substitution $(...)  in command definitions",
+    "# Word Extraction & Command Substitution": "Tests for various bash syntaxes in command paths",
 
     # Test basic command substitution in command path using echo (portable across systems)
-    "test.testSubshellPath": {
-        "cmd": "test.testSubshellPath 'Command substitution works!'",
+    "subshell.subshellPath": {
+        "cmd": "subshell.subshellPath 'Command substitution works!'",
         "see": "Command substitution works!",
-        "description": "REGRESSION: Command substitution in path - $(echo /usr/bin)/echo should properly expand and execute"
+        "description": "REGRESSION: Command substitution $(...) - should properly extract as atomic unit"
+    },
+
+    # Test command substitution in command path (alternative form)
+    "subshell.backtickPath": {
+        "cmd": "subshell.backtickPath 'Backtick works!'",
+        "see": "Backtick works!",
+        "description": "REGRESSION: Backtick command substitution `...` - should properly extract as atomic unit"
+    },
+
+    # Test double-quoted argument with spaces
+    "subshell.quotedArg": {
+        "cmd": "subshell.quotedArg",
+        "see": "This is a quoted string",
+        "description": "REGRESSION: Double-quoted strings with spaces - should not split on spaces inside quotes"
+    },
+
+    # Test single-quoted argument (preserves literal characters)
+    "subshell.singleQuotedArg": {
+        "cmd": "subshell.singleQuotedArg",
+        "see": "Single quoted: \\$VARIABLE",
+        "description": "REGRESSION: Single-quoted strings - should preserve literal characters and not expand variables"
+    },
+
+    # Test process substitution <(...)
+    "subshell.processSub": {
+        "cmd": "subshell.processSub",
+        "see": "hello",
+        "description": "REGRESSION: Process substitution <(...) - should properly extract as atomic unit"
+    },
+
+    # Test complex parameter expansion
+    "subshell.complexExpansion": {
+        "cmd": "subshell.complexExpansion",
+        "see": "/bin/echo",
+        "description": "REGRESSION: Complex parameter expansion ${...} - should handle colons and slashes"
+    },
+
+    # Test command substitution in path
+    "subshell.subshellPath": {
+        "cmd": "subshell.subshellPath 'Command substitution works!'",
+        "see": "Command substitution works!",
+        "description": "REGRESSION: Command substitution in path - should extract $(echo /usr/bin)/echo correctly"
+    },
+
+    # Additional edge case variations
+    "subshell.processSubOut": {
+        "cmd": "subshell.processSubOut <<< 'test'",
+        "see": "test",
+        "description": "REGRESSION: Process substitution output form >(...)  - should extract correctly"
+    },
+
+    "subshell.escapedSpace": {
+        "cmd": "subshell.escapedSpace",
+        "see": "hello world",
+        "description": "REGRESSION: Escaped spaces in arguments - should not split on escaped spaces"
+    },
+
+    "subshell.nestedSub": {
+        "cmd": "subshell.nestedSub",
+        "see": "2026",
+        "description": "REGRESSION: Nested command substitution $(echo $(echo 2026)) - should extract correctly"
+    },
+
+    "subshell.mixedQuotes": {
+        "cmd": "subshell.mixedQuotes",
+        "see": "single double",
+        "description": "REGRESSION: Mixed single and double quotes - should preserve both quote types"
+    },
+
+    "subshell.quotedWithSub": {
+        "cmd": "subshell.quotedWithSub",
+        "see": "Today is",
+        "description": "REGRESSION: Double-quoted string with command substitution inside - should extract correctly"
+    },
+
+    "subshell.paramDefault": {
+        "cmd": "subshell.paramDefault",
+        "see": "fallback",
+        "description": "REGRESSION: Parameter expansion with default value ${VAR:-default} - should extract correctly"
+    },
+
+    "subshell.paramSubstr": {
+        "cmd": "subshell.paramSubstr",
+        "see": "/bin",
+        "description": "REGRESSION: Parameter expansion with substring offset ${VAR:0:4} - should extract correctly"
+    },
+
+    "subshell.paramPattern": {
+        "cmd": "subshell.paramPattern",
+        "see": "test",
+        "description": "REGRESSION: Simple parameter expansion test - should extract correctly"
+    },
+
+    "subshell.multiSub": {
+        "cmd": "subshell.multiSub",
+        "see": "helloworld",
+        "description": "REGRESSION: Multiple consecutive command substitutions in word - should extract correctly"
+    },
+
+    "subshell.subWithSpaces": {
+        "cmd": "subshell.subWithSpaces",
+        "see": "spaced output",
+        "description": "REGRESSION: Escaped spaces in command - should preserve spaces"
+    },
+
+    "subshell.escapedDollar": {
+        "cmd": "subshell.escapedDollar",
+        "see": "Literal: \\$VARIABLE",
+        "description": "REGRESSION: Literal dollar sign with single quotes - should output literal \\$"
     },
 }

--- a/test/test_cases/named_parameters.py
+++ b/test/test_cases/named_parameters.py
@@ -1,0 +1,375 @@
+# Test cases for named parameter delimiter preservation
+# Ensures that ':' and '=' delimiters are preserved in parameter passing
+# All tests run from projectNamedParam directory
+
+test_cases = {
+    # ========== SINGLE PARAMETER TESTS ==========
+    
+    # Colon delimiter - parameter referenced in command
+    "namedparam.refSingleColon action:build": {
+        "cmd": "namedparam.refSingleColon action:build",
+        "pwd": "projectNamedParam",
+        "see": "referenced:build$",
+    },
+    "namedparam.refSingleColon action:deploy": {
+        "cmd": "namedparam.refSingleColon action:deploy",
+        "pwd": "projectNamedParam",
+        "see": "referenced:deploy$",
+    },
+    
+    # Equals delimiter - parameter referenced in command
+    "namedparam.refSingleEquals action=build": {
+        "cmd": "namedparam.refSingleEquals action=build",
+        "pwd": "projectNamedParam",
+        "see": "referenced=build$",
+    },
+    "namedparam.refSingleEquals action=deploy": {
+        "cmd": "namedparam.refSingleEquals action=deploy",
+        "pwd": "projectNamedParam",
+        "see": "referenced=deploy$",
+    },
+    
+    # Colon delimiter - parameter NOT referenced (should pass through)
+    "namedparam.passthrough action:build": {
+        "cmd": "namedparam.passthrough action:build",
+        "pwd": "projectNamedParam",
+        "see": "^no-substitution-here action:build$",
+    },
+    "namedparam.passthrough action:test": {
+        "cmd": "namedparam.passthrough action:test",
+        "pwd": "projectNamedParam",
+        "see": "^no-substitution-here action:test$",
+    },
+    
+    # Equals delimiter - parameter NOT referenced (should pass through)
+    "namedparam.passthrough action=build": {
+        "cmd": "namedparam.passthrough action=build",
+        "pwd": "projectNamedParam",
+        "see": "^no-substitution-here action=build$",
+    },
+    "namedparam.passthrough action=test": {
+        "cmd": "namedparam.passthrough action=test",
+        "pwd": "projectNamedParam",
+        "see": "^no-substitution-here action=test$",
+    },
+    
+    # ========== MULTIPLE PARAMETER TESTS ==========
+    
+    # Multiple parameters with colon delimiter - all referenced
+    "namedparam.refMultiColon action:start target:finish": {
+        "cmd": "namedparam.refMultiColon action:start target:finish",
+        "pwd": "projectNamedParam",
+        "see": "^start:finish:done$",
+    },
+    "namedparam.refMultiColon action:begin target:end": {
+        "cmd": "namedparam.refMultiColon action:begin target:end",
+        "pwd": "projectNamedParam",
+        "see": "^begin:end:done$",
+    },
+    
+    # Multiple parameters with equals delimiter - all referenced
+    "namedparam.refMultiEquals action=start target=finish": {
+        "cmd": "namedparam.refMultiEquals action=start target=finish",
+        "pwd": "projectNamedParam",
+        "see": "^start=finish=done$",
+    },
+    "namedparam.refMultiEquals action=begin target=end": {
+        "cmd": "namedparam.refMultiEquals action=begin target=end",
+        "pwd": "projectNamedParam",
+        "see": "^begin=end=done$",
+    },
+    
+    # ========== MIXED DELIMITER TESTS ==========
+    
+    # Mixed delimiters on different parameters - all referenced
+    "namedparam.refMixed action:deploy target=production": {
+        "cmd": "namedparam.refMixed action:deploy target=production",
+        "pwd": "projectNamedParam",
+        "see": "^deploy:production$",
+    },
+    "namedparam.refMixed action=build target:staging": {
+        "cmd": "namedparam.refMixed action=build target:staging",
+        "pwd": "projectNamedParam",
+        "see": "^build:staging$",
+    },
+    
+    # Multiple params with mixed delimiters - not all referenced (should pass through)
+    "namedparam.passthroughEcho action:build target=staging": {
+        "cmd": "namedparam.passthroughEcho action:build target=staging",
+        "pwd": "projectNamedParam",
+        "see": "^Original command action:build target=staging$",
+    },
+    "namedparam.passthroughEcho action=deploy target:prod": {
+        "cmd": "namedparam.passthroughEcho action=deploy target:prod",
+        "pwd": "projectNamedParam",
+        "see": "^Original command action=deploy target:prod$",
+    },
+    
+    # ========== PARTIAL REFERENCE TESTS ==========
+    
+    # One parameter referenced with colon, one passed through
+    "namedparam.refPartial action:build mode:fast": {
+        "cmd": "namedparam.refPartial action:build mode:fast",
+        "pwd": "projectNamedParam",
+        "see": "^Referenced:build mode:fast$",
+    },
+    "namedparam.refPartial action:deploy mode:slow": {
+        "cmd": "namedparam.refPartial action:deploy mode:slow",
+        "pwd": "projectNamedParam",
+        "see": "^Referenced:deploy mode:slow$",
+    },
+    
+    # One parameter referenced with equals, one passed through (command uses '=')
+    "namedparam.refPartialEquals action=deploy mode=slow": {
+        "cmd": "namedparam.refPartialEquals action=deploy mode=slow",
+        "pwd": "projectNamedParam",
+        "see": "^Referenced=deploy mode=slow$",
+    },
+    "namedparam.refPartialEquals action=build opt1=yes opt2=no": {
+        "cmd": "namedparam.refPartialEquals action=build opt1=yes opt2=no",
+        "pwd": "projectNamedParam",
+        "see": "^Referenced=build opt1=yes opt2=no$",
+    },
+    
+    # Multiple parameters, some referenced, some not (colon delimiter)
+    "namedparam.refPartialMulti action:test cmd:deploy": {
+        "cmd": "namedparam.refPartialMulti action:test cmd:deploy",
+        "pwd": "projectNamedParam",
+        "see": "^Action:test Command: passthrough cmd:deploy$",
+    },
+    # Multiple parameters, some referenced, some not (equals delimiter)
+    "namedparam.refPartialMultiEquals action=build cmd=run": {
+        "cmd": "namedparam.refPartialMultiEquals action=build cmd=run",
+        "pwd": "projectNamedParam",
+        "see": "^Action=build Command: passthrough cmd=run$",
+    },
+    
+    # ========== DUPLICATE PARAMETER TESTS ==========
+    
+    # Same parameter referenced multiple times - colon delimiter
+    "namedparam.refDuplicate action:test": {
+        "cmd": "namedparam.refDuplicate action:test",
+        "pwd": "projectNamedParam",
+        "see": "^test-then-test$",
+    },
+    "namedparam.refDuplicate action:x": {
+        "cmd": "namedparam.refDuplicate action:x",
+        "pwd": "projectNamedParam",
+        "see": "^x-then-x$",
+    },
+    
+    # Same parameter referenced multiple times - equals delimiter
+    "namedparam.refDuplicate action=deploy": {
+        "cmd": "namedparam.refDuplicate action=deploy",
+        "pwd": "projectNamedParam",
+        "see": "^deploy-then-deploy$",
+    },
+    "namedparam.refDuplicate action=y": {
+        "cmd": "namedparam.refDuplicate action=y",
+        "pwd": "projectNamedParam",
+        "see": "^y-then-y$",
+    },
+    
+    # ========== PARAMETER POSITION TESTS ==========
+    
+    # Parameter in middle of command - colon delimiter
+    "namedparam.refMiddle action:mid": {
+        "cmd": "namedparam.refMiddle action:mid",
+        "pwd": "projectNamedParam",
+        "see": "^mid middle-text end$",
+    },
+    "namedparam.refMiddle action:center": {
+        "cmd": "namedparam.refMiddle action:center",
+        "pwd": "projectNamedParam",
+        "see": "^center middle-text end$",
+    },
+    
+    # Parameter in middle of command - equals delimiter
+    "namedparam.refMiddle action=mid": {
+        "cmd": "namedparam.refMiddle action=mid",
+        "pwd": "projectNamedParam",
+        "see": "^mid middle-text end$",
+    },
+    "namedparam.refMiddle action=center": {
+        "cmd": "namedparam.refMiddle action=center",
+        "pwd": "projectNamedParam",
+        "see": "^center middle-text end$",
+    },
+    
+    # Parameter at end of command - colon delimiter
+    "namedparam.refEnd action:finish": {
+        "cmd": "namedparam.refEnd action:finish",
+        "pwd": "projectNamedParam",
+        "see": "^start middle finish$",
+    },
+    "namedparam.refEnd action:x": {
+        "cmd": "namedparam.refEnd action:x",
+        "pwd": "projectNamedParam",
+        "see": "^start middle x$",
+    },
+    
+    # Parameter at end of command - equals delimiter
+    "namedparam.refEnd action=complete": {
+        "cmd": "namedparam.refEnd action=complete",
+        "pwd": "projectNamedParam",
+        "see": "^start middle complete$",
+    },
+    "namedparam.refEnd action=z": {
+        "cmd": "namedparam.refEnd action=z",
+        "pwd": "projectNamedParam",
+        "see": "^start middle z$",
+    },
+    
+    # ========== EDGE CASES AND COMBINATIONS ==========
+    
+    # Multiple parameters of same type with different delimiters (all referenced)
+    "namedparam.refMultiColon action:deploy target:live": {
+        "cmd": "namedparam.refMultiColon action:deploy target:live",
+        "pwd": "projectNamedParam",
+        "see": "^deploy:live:done$",
+    },
+    "namedparam.refMultiEquals action=deploy target=live": {
+        "cmd": "namedparam.refMultiEquals action=deploy target=live",
+        "pwd": "projectNamedParam",
+        "see": "^deploy=live=done$",
+    },
+    
+    # Pass through with multiple unreferenced parameters (order may vary due to hash iteration)
+    "namedparam.passthrough x:y z:a": {
+        "cmd": "namedparam.passthrough x:y z:a",
+        "pwd": "projectNamedParam",
+        "see": "no-substitution-here.*(x:y|z:a).*(x:y|z:a)",
+    },
+    "namedparam.passthrough x=1 y=2 z=3": {
+        "cmd": "namedparam.passthrough x=1 y=2 z=3",
+        "pwd": "projectNamedParam",
+        "see": "no-substitution-here.*(x=1|y=2|z=3).*(x=1|y=2|z=3).*(x=1|y=2|z=3)",
+    },
+    
+    # Mixed delimiter passthrough (order may vary)
+    "namedparam.passthrough x:1 y=2 z:3": {
+        "cmd": "namedparam.passthrough x:1 y=2 z:3",
+        "pwd": "projectNamedParam",
+        "see": "no-substitution-here.*(x:1|y=2|z:3).*(x:1|y=2|z:3).*(x:1|y=2|z:3)",
+    },
+    
+    # Partial reference with multiple unreferenced params (order may vary for unreferenced)
+    "namedparam.refPartial action:test mode:fast speed:high": {
+        "cmd": "namedparam.refPartial action:test mode:fast speed:high",
+        "pwd": "projectNamedParam",
+        "see": "^Referenced:test (mode:fast|speed:high).*(mode:fast|speed:high)",
+    },
+    
+    # ========== EMPTY VALUE TESTS ==========
+    
+    # Empty value with colon delimiter - referenced parameter
+    "namedparam.refSingleColon action:": {
+        "cmd": "namedparam.refSingleColon action:",
+        "pwd": "projectNamedParam",
+        "see": "^referenced:$",
+    },
+    
+    # Empty value with equals delimiter - referenced parameter
+    "namedparam.refSingleEquals action=": {
+        "cmd": "namedparam.refSingleEquals action=",
+        "pwd": "projectNamedParam",
+        "see": "^referenced=$",
+    },
+    
+    # Empty value with colon delimiter - passthrough (not referenced)
+    "namedparam.passthrough action:": {
+        "cmd": "namedparam.passthrough action:",
+        "pwd": "projectNamedParam",
+        "see": "^no-substitution-here action:$",
+    },
+    
+    # Empty value with equals delimiter - passthrough (not referenced)
+    "namedparam.passthrough action=": {
+        "cmd": "namedparam.passthrough action=",
+        "pwd": "projectNamedParam",
+        "see": "^no-substitution-here action=$",
+    },
+    
+    # Multiple parameters, one with empty value - all referenced
+    "namedparam.refMultiColon action: target:done": {
+        "cmd": "namedparam.refMultiColon action: target:done",
+        "pwd": "projectNamedParam",
+        "see": "^:done:done$",
+    },
+    "namedparam.refMultiColon action:start target:": {
+        "cmd": "namedparam.refMultiColon action:start target:",
+        "pwd": "projectNamedParam",
+        "see": "^start::done$",
+    },
+    "namedparam.refMultiEquals action= target=done": {
+        "cmd": "namedparam.refMultiEquals action= target=done",
+        "pwd": "projectNamedParam",
+        "see": "^=done=done$",
+    },
+    "namedparam.refMultiEquals action=start target=": {
+        "cmd": "namedparam.refMultiEquals action=start target=",
+        "pwd": "projectNamedParam",
+        "see": "^start==done$",
+    },
+    
+    # Mixed empty and non-empty values
+    "namedparam.refMixed action: target=production": {
+        "cmd": "namedparam.refMixed action: target=production",
+        "pwd": "projectNamedParam",
+        "see": "^:production$",
+    },
+    "namedparam.refMixed action=build target:": {
+        "cmd": "namedparam.refMixed action=build target:",
+        "pwd": "projectNamedParam",
+        "see": "^build:$",
+    },
+    
+    # Empty values in passthrough with multiple parameters
+    "namedparam.passthrough x: y=": {
+        "cmd": "namedparam.passthrough x: y=",
+        "pwd": "projectNamedParam",
+        "see": "no-substitution-here.*(x:|y=).*(x:|y=)",
+    },
+    "namedparam.passthrough x= y:": {
+        "cmd": "namedparam.passthrough x= y:",
+        "pwd": "projectNamedParam",
+        "see": "no-substitution-here.*(x=|y:).*(x=|y:)",
+    },
+    
+    # Partial reference with empty value
+    "namedparam.refPartial action: mode=fast": {
+        "cmd": "namedparam.refPartial action: mode=fast",
+        "pwd": "projectNamedParam",
+        "see": "^Referenced: mode=fast$",
+    },
+    "namedparam.refPartialEquals action= mode:slow": {
+        "cmd": "namedparam.refPartialEquals action= mode:slow",
+        "pwd": "projectNamedParam",
+        "see": "^Referenced= mode:slow$",
+    },
+    
+    # Duplicate parameter with empty value
+    "namedparam.refDuplicate action:": {
+        "cmd": "namedparam.refDuplicate action:",
+        "pwd": "projectNamedParam",
+        "see": "^-then-$",
+    },
+    "namedparam.refDuplicate action=": {
+        "cmd": "namedparam.refDuplicate action=",
+        "pwd": "projectNamedParam",
+        "see": "^-then-$",
+    },
+    
+    # Parameters in middle/end position with empty values
+    "namedparam.refMiddle action:": {
+        "cmd": "namedparam.refMiddle action:",
+        "pwd": "projectNamedParam",
+        "see": "^middle-text end$",
+    },
+    "namedparam.refEnd action=": {
+        "cmd": "namedparam.refEnd action=",
+        "pwd": "projectNamedParam",
+        "see": "^start middle",
+    },
+}
+


### PR DESCRIPTION
The following changes are included in this PR:

* Increased variable substitution max loop count to avoid claiming infinite loop detection on complex/long commands

* **BugFix: Named Parameter Delimiter Preservation** - When a named parameter (e.g. `key:value`) is not referenced in the command definition, it was being reconstructed with `=` instead of the original delimiter
  * Arguments using `:` delimiter (e.g. `my artisan log:test-prints`) now correctly pass through as `log:test-prints` instead of `log=test-prints`
  * The original delimiter (`:` or `=`) is now captured during argument extraction and preserved when passing unconsumed parameters through to the underlying command

* **Enhanced Word Extraction Parser** - Replaced simple `read -ra` word splitting with bash syntax-aware character-by-character parser
  * Now properly handles command substitution `$(...)` with parenthesis depth tracking
  * Supports backtick command substitution `` `...` ``
  * Respects single quotes `'...'` and double quotes `"..."` with separate state tracking
  * Handles process substitution `<(...)` and `>(...)` with parenthesis nesting
  * Properly processes escaped characters via backslash escaping
  * Supports complex parameter expansion patterns `${VAR}`, `${VAR:offset}`, `${VAR#pattern}`, etc.
  * Fixed critical bug with boolean variable handling causing "1: command not found" errors
  * Fixed regex syntax error in process substitution detection pattern
